### PR TITLE
Store user profiles in Firestore on registration

### DIFF
--- a/rideshare-app/screens/Register.js
+++ b/rideshare-app/screens/Register.js
@@ -2,6 +2,8 @@ import { useMemo, useState } from "react";
 import { Picker } from "@react-native-picker/picker";
 import { createUserWithEmailAndPassword } from "firebase/auth";
 import { auth } from "../src/firebase";
+import { doc, setDoc, serverTimestamp } from "firebase/firestore";
+import { db } from "../src/firebase";
 
 import { View, Text, TextInput, TouchableOpacity, StyleSheet, ScrollView, } from "react-native";
 
@@ -128,11 +130,21 @@ export default function Register({ onBack }) {
     };
 
     try {
-      await createUserWithEmailAndPassword(
+      const cred = await createUserWithEmailAndPassword(
         auth,
         payload.email,
         payload.password
       );
+
+      await setDoc(doc(db, "users", cred.user.uid), {
+        name: payload.name,
+        bio: payload.bio,
+        payHandle: payload.payHandle,
+        phone: payload.phone,
+        email: payload.email,
+        vehicles: payload.vehicles,
+        createdAt: serverTimestamp(),
+      });
 
       alert("Account created! Now go log in.");
       onBack(); // go back to login screen

--- a/rideshare-app/src/firebase.js
+++ b/rideshare-app/src/firebase.js
@@ -1,6 +1,7 @@
 // src/firebase.js
 import { initializeApp, getApp, getApps } from "firebase/app";
 import { getAuth } from "firebase/auth";
+import { getFirestore } from "firebase/firestore";
 
 const firebaseConfig = {
   apiKey: "AIzaSyCGaKmpxxrKF4gRez_gCm8JJ2ZVD_QXXIo",
@@ -15,3 +16,5 @@ const firebaseConfig = {
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
 export const auth = getAuth(app);
+export const db = getFirestore(app);
+


### PR DESCRIPTION
This PR extends Firebase Auth registration by storing user profile data in Firestore.

Changes:
- Export Firestore instance from firebase config
- Create users/{uid} document on successful registration
- Store profile fields (name, bio, phone, vehicles, etc.)
- Add server timestamp for account creation

Tested:
- Registration succeeds in Expo Go
- Firestore document is created automatically under users/{uid}
- Firestore security rules allow users to write only their own profile
