### PR TITLE
Removed phone and email from pop-ups

### DIFF
--- a/rideshare-app/app/(tabs)/home/index.js
+++ b/rideshare-app/app/(tabs)/home/index.js
@@ -477,14 +477,6 @@ export default function Homepage({ user }) {
                     <Text style={styles.modalInfoValue}>{driverInfo?.name || selectedRide.ownerName}</Text>
                   </View>
                   <View style={styles.modalInfoRow}>
-                    <Text style={styles.modalInfoLabel}>Email:</Text>
-                    <Text style={styles.modalInfoValue}>{driverInfo?.email || selectedRide.ownerEmail}</Text>
-                  </View>
-                  <View style={styles.modalInfoRow}>
-                    <Text style={styles.modalInfoLabel}>Phone:</Text>
-                    <Text style={styles.modalInfoValue}>{formatPhoneNumber(driverInfo?.phone)}</Text>
-                  </View>
-                  <View style={styles.modalInfoRow}>
                     <Text style={styles.modalInfoLabel}>Pay Handle:</Text>
                     <Text style={styles.modalInfoValue}>{driverInfo?.payHandle || 'Not provided'}</Text>
                   </View>

--- a/rideshare-app/app/(tabs)/home/joinpage.js
+++ b/rideshare-app/app/(tabs)/home/joinpage.js
@@ -664,14 +664,6 @@ export default function JoinPage() {
                         <Text style={styles.modalInfoValue}>{driverInfo?.name || selectedRide.ownerName}</Text>
                       </View>
                       <View style={styles.modalInfoRow}>
-                        <Text style={styles.modalInfoLabel}>Email:</Text>
-                        <Text style={styles.modalInfoValue}>{driverInfo?.email || selectedRide.ownerEmail}</Text>
-                      </View>
-                      <View style={styles.modalInfoRow}>
-                        <Text style={styles.modalInfoLabel}>Phone:</Text>
-                        <Text style={styles.modalInfoValue}>{formatPhoneNumber(driverInfo?.phone)}</Text>
-                      </View>
-                      <View style={styles.modalInfoRow}>
                         <Text style={styles.modalInfoLabel}>Pay Handle:</Text>
                         <Text style={styles.modalInfoValue}>{driverInfo?.payHandle || "Not provided"}</Text>
                       </View>


### PR DESCRIPTION
Removed phone number and email from pop-up cards to preserve driver's privacy.
<img width="300" height="1266" alt="IMG_0029" src="https://github.com/user-attachments/assets/b147fb48-d725-4244-a034-ddf99ee14a0f" />
