### PR TITLE
Fixed the issue with the keyboard blocking the final fields

### DIFF
--- a/rideshare-app/app/(auth)/register.js
+++ b/rideshare-app/app/(auth)/register.js
@@ -12,6 +12,8 @@ import {
   TouchableOpacity,
   StyleSheet,
   ScrollView,
+  KeyboardAvoidingView,
+  Platform,
 } from "react-native";
 
 import { router } from "expo-router";
@@ -164,15 +166,19 @@ export default function Register() {
   };
 
   return (
-    <ScrollView
-      contentContainerStyle={styles.container}
-      keyboardShouldPersistTaps="handled"
+    <KeyboardAvoidingView
+      style={{ flex: 1 }}
+      behavior={Platform.OS === "ios" ? "padding" : "height"}
     >
-      {/* Title */}
-      <Text style={styles.header}>Create Account</Text>
-      <Text style={styles.subheader}>
-        Enter your details to join UCSB Rideshare
-      </Text>
+      <ScrollView
+        contentContainerStyle={styles.container}
+        keyboardShouldPersistTaps="handled"
+      >
+        {/* Title */}
+        <Text style={styles.header}>Create Account</Text>
+        <Text style={styles.subheader}>
+          Enter your details to join UCSB Rideshare
+        </Text>
 
       {/* White Card */}
       <View style={styles.card}>
@@ -420,13 +426,14 @@ export default function Register() {
       </View>
 
       {/* Back */}
-      <TouchableOpacity
-        onPress={() => router.replace("/(auth)/login")}
-        style={{ marginTop: 18 }}
-      >
-        <Text style={styles.back}>Back to Login</Text>
-      </TouchableOpacity>
-    </ScrollView>
+        <TouchableOpacity
+          onPress={() => router.replace("/(auth)/login")}
+          style={{ marginTop: 18 }}
+        >
+          <Text style={styles.back}>Back to Login</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 

--- a/rideshare-app/app/(tabs)/account/accountpage.js
+++ b/rideshare-app/app/(tabs)/account/accountpage.js
@@ -8,6 +8,7 @@ import {
   ScrollView,
   TextInput,
   TouchableOpacity,
+  KeyboardAvoidingView,
 } from 'react-native';
 import { router } from 'expo-router';
 import { colors } from '../../../ui/styles/colors';
@@ -152,8 +153,13 @@ export default function AccountPage() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <ScrollView contentContainerStyle={styles.content}>
-        <Text style={styles.title}>Account</Text>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 88 : 0}
+      >
+        <ScrollView contentContainerStyle={styles.content} keyboardShouldPersistTaps="handled">
+          <Text style={styles.title}>Account</Text>
 
         <View style={styles.card}>
           <View style={styles.headerRow}>
@@ -285,7 +291,8 @@ export default function AccountPage() {
             </TouchableOpacity>
           </View>
         </View>
-      </ScrollView>
+        </ScrollView>
+      </KeyboardAvoidingView>
       <NavBar />
     </SafeAreaView>
   );

--- a/rideshare-app/app/(tabs)/home/hostpage.js
+++ b/rideshare-app/app/(tabs)/home/hostpage.js
@@ -13,6 +13,7 @@ import {
   Pressable,
   ActivityIndicator,
   SafeAreaView,
+  KeyboardAvoidingView,
 } from "react-native";
 import { colors } from "../../../ui/styles/colors";
 import {
@@ -237,13 +238,19 @@ export default function HostPage() {
 
   return (
     <SafeAreaView style={{ flex: 1, backgroundColor: "#fff" }}>
-      <ScrollView 
-        contentContainerStyle={[
-          styles.container,
-          { paddingBottom: Platform.OS === 'ios' ? 108 : 80 }
-        ]}
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === "ios" ? "padding" : "height"}
+        keyboardVerticalOffset={Platform.OS === "ios" ? 88 : 0}
       >
-        <Text style={styles.title}>Host a Ride</Text>
+        <ScrollView
+          contentContainerStyle={[
+            styles.container,
+            { paddingBottom: Platform.OS === "ios" ? 108 : 80 },
+          ]}
+          keyboardShouldPersistTaps="handled"
+        >
+          <Text style={styles.title}>Host a Ride</Text>
 
         {/* Owner Name (pulled from profile) */}
         <View style={[styles.fieldGroup, styles.firstFieldGroup]}>
@@ -467,7 +474,8 @@ export default function HostPage() {
             {isSaving ? "Saving..." : "Submit"}
           </Text>
         </TouchableOpacity>
-      </ScrollView>
+        </ScrollView>
+      </KeyboardAvoidingView>
 
       <NavBar />
     </SafeAreaView>


### PR DESCRIPTION
Closes #151 
Closes #152

- Wrapped the forms on the host page, account edit page, and registration page in KeyboardAvoidingView so iOS shifts content up when the keyboard appears.
- Set behavior="padding" on iOS to move the content above the keyboard; Android uses "height" as a safe fallback.
- Added keyboardVerticalOffset on the tab pages to account for the bottom nav bar height (prevents overlap with the fixed nav).
-Kept the form inside a ScrollView with keyboardShouldPersistTaps="handled" so taps on inputs work smoothly while the keyboard is open.

This fix creates a better experience for all users since they easily edit the final field in each page without having to click in and out just for a simple preview of what they are typing.


<img width="603" height="1311" alt="IMG_6399" src="https://github.com/user-attachments/assets/5d876090-1dd9-41eb-93b7-5a6a5c8f06e4" />

<img width="603" height="1311" alt="IMG_6398" src="https://github.com/user-attachments/assets/0ea66c00-a8ff-42da-8c30-24c8e1a0ae26" />

<img width="603" height="1311" alt="IMG_6397" src="https://github.com/user-attachments/assets/3d836485-60ab-4cc6-92c0-79834cf1b825" />
