### PR TITLE
added names above chat bubbles on messaging page

### DIFF
--- a/rideshare-app/app/(tabs)/messages/chat.js
+++ b/rideshare-app/app/(tabs)/messages/chat.js
@@ -236,7 +236,11 @@ export default function ChatScreen() {
           </View>
         )}
 
-        {/* Bubble */}
+        {/* Bubble (wrapped with name label for others) */}
+        <View style={styles.bubbleWrapper}>
+          {!isMyMessage && (
+            <Text style={styles.senderName}>{senderDisplayName}</Text>
+          )}
         <View
           style={[
             styles.messageContainer,
@@ -260,6 +264,7 @@ export default function ChatScreen() {
           >
             {formatMessageTime(item.createdAt)}
           </Text>
+        </View>
         </View>
       </View>
     </>
@@ -475,7 +480,6 @@ const styles = StyleSheet.create({
     marginVertical: 16,
   },
   messageContainer: {
-    maxWidth: '75%',
     marginVertical: 4,
     paddingHorizontal: 14,
     paddingVertical: 10,
@@ -627,5 +631,16 @@ const styles = StyleSheet.create({
     color: '#fff',
     fontSize: 13,
     fontWeight: '700',
+  },
+  bubbleWrapper: {
+    flexShrink: 1,
+    maxWidth: '75%',
+  },
+  senderName: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.textSecondary,
+    marginBottom: 3,
+    marginLeft: 4,
   },
 });


### PR DESCRIPTION
Description:

In group ride chats, sender names now appear above each message bubble for messages from other participants, similar to iMessage group chat behavior. The name is pulled from senderName on the message document, with a fallback to participantNames on the conversation document.

Changes:

Wrapped message bubbles in a bubbleWrapper View to contain the name label + bubble together
Added senderName label that renders above bubbles for other participants' messages
Moved maxWidth: '75%' from messageContainer to bubbleWrapper to keep name labels properly aligned with their bubbles

Testing:

Opened a ride group chat with multiple participants
Verified sender names appear above bubbles for other users' messages
Verified no name label appears above your own messages
Verified layout is correct on iOS via Expo Go