### PR TITLE
Driver cancellation feature

### DIFF
--- a/rideshare-app/app/(tabs)/home/index.js
+++ b/rideshare-app/app/(tabs)/home/index.js
@@ -12,6 +12,9 @@ import {
   Image,
   Modal,
   Platform,
+  Keyboard,
+  KeyboardAvoidingView,
+  Pressable,
 } from 'react-native';
 import { collection, query, where, onSnapshot, doc, getDoc, runTransaction } from 'firebase/firestore';
 import { auth, db } from '../../../src/firebase';
@@ -703,97 +706,115 @@ export default function Homepage({ user }) {
 
           {/* Cancel Ride Confirmation Overlay (Driver) */}
           {cancelRideModalVisible && (
-            <View style={styles.confirmModalOverlay}>
-              <View style={styles.confirmModalContent}>
-                <Text style={styles.confirmModalTitle}>Cancel this ride?</Text>
-
-                <Text style={styles.confirmModalMessage}>
-                  Please provide a cancellation note (required). Riders will see this note.
-                </Text>
-
-                <TextInput
-                  style={styles.cancelNoteInput}
-                  value={cancelNote}
-                  onChangeText={(t) => {
-                    setCancelNote(t);
-                    if (cancelNoteError) setCancelNoteError('');
-                  }}
-                  placeholder="E.g., Car trouble / emergency / schedule conflict..."
-                  multiline
-                  editable={!cancellingRide}
-                />
-
-                {!!cancelNoteError && (
-                  <Text style={styles.cancelNoteErrorText}>{cancelNoteError}</Text>
-                )}
-
-                <View style={styles.confirmModalButtons}>
-                  <TouchableOpacity
-                    style={styles.confirmCancelButton}
-                    onPress={() => setCancelRideModalVisible(false)}
-                    disabled={cancellingRide}
+            <Pressable
+              style={styles.confirmModalOverlay}
+              onPress={Keyboard.dismiss}
+            >
+              <KeyboardAvoidingView
+                style={{ width: '100%', alignItems: 'center' }}
+                behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+                keyboardVerticalOffset={Platform.OS === 'ios' ? 24 : 0}
+              >
+                {/* prevent taps inside the card from dismissing by accident */}
+                <Pressable onPress={() => {}} style={styles.confirmModalContent}>
+                  <ScrollView
+                    keyboardShouldPersistTaps="handled"
+                    contentContainerStyle={{ paddingBottom: 12 }}
+                    showsVerticalScrollIndicator={false}
                   >
-                    <Text style={styles.confirmCancelButtonText}>Go Back</Text>
-                  </TouchableOpacity>
+                    <Text style={styles.confirmModalTitle}>Cancel this ride?</Text>
 
-                  <TouchableOpacity
-                    style={[styles.confirmLeaveButton, cancellingRide && styles.buttonDisabled]}
-                    disabled={cancellingRide}
-                    onPress={async () => {
-                      const trimmed = cancelNote.trim();
-                      if (!trimmed) {
-                        setCancelNoteError('Cancellation note is required.');
-                        return;
-                      }
-                      if (!selectedRide) return;
+                    <Text style={styles.confirmModalMessage}>
+                      Please provide a cancellation note (required). Riders will see this note.
+                    </Text>
 
-                      setCancellingRide(true);
-                      try {
-                        const currentUser = auth.currentUser;
-                        if (!currentUser) return;
+                    <TextInput
+                      style={styles.cancelNoteInput}
+                      value={cancelNote}
+                      onChangeText={(t) => {
+                        setCancelNote(t);
+                        if (cancelNoteError) setCancelNoteError('');
+                      }}
+                      placeholder="E.g., Car trouble / emergency / schedule conflict..."
+                      multiline
+                      editable={!cancellingRide}
+                      returnKeyType="done"
+                      submitBehavior="blurAndSubmit"
+                      onSubmitEditing={Keyboard.dismiss}
+                    />
 
-                        const rideRef = doc(db, 'rides', selectedRide.id);
-
-                        await runTransaction(db, async (tx) => {
-                          const rideSnap = await tx.get(rideRef);
-                          if (!rideSnap.exists()) throw new Error('Ride no longer exists.');
-
-                          const rideData = rideSnap.data() || {};
-                          if (rideData.ownerId !== currentUser.uid) {
-                            throw new Error('Only the driver can cancel this ride.');
-                          }
-
-                          tx.update(rideRef, {
-                            status: 'cancelled',
-                            cancelledAt: new Date().toISOString(),
-                            cancelledBy: currentUser.uid,
-                            cancellationNote: trimmed,
-                          });
-                        });
-
-                        // Close modals + reset state
-                        setCancelRideModalVisible(false);
-                        setDetailsModalVisible(false);
-                        setSelectedRide(null);
-                        setDriverInfo(null);
-                        setDriverVehicle(null);
-                      } catch (e) {
-                        console.error('Error cancelling ride:', e);
-                        alert('Failed to cancel ride. Please try again.');
-                      } finally {
-                        setCancellingRide(false);
-                      }
-                    }}
-                  >
-                    {cancellingRide ? (
-                      <ActivityIndicator size="small" color={colors.white} />
-                    ) : (
-                      <Text style={styles.confirmLeaveButtonText}>Confirm Cancel</Text>
+                    {!!cancelNoteError && (
+                      <Text style={styles.cancelNoteErrorText}>{cancelNoteError}</Text>
                     )}
-                  </TouchableOpacity>
-                </View>
-              </View>
-            </View>
+
+                    <View style={styles.confirmModalButtons}>
+                      <TouchableOpacity
+                        style={styles.confirmCancelButton}
+                        onPress={() => setCancelRideModalVisible(false)}
+                        disabled={cancellingRide}
+                      >
+                        <Text style={styles.confirmCancelButtonText}>Go Back</Text>
+                      </TouchableOpacity>
+
+                      <TouchableOpacity
+                        style={[styles.confirmLeaveButton, cancellingRide && styles.buttonDisabled]}
+                        disabled={cancellingRide}
+                        onPress={async () => {
+                          const trimmed = cancelNote.trim();
+                          if (!trimmed) {
+                            setCancelNoteError('Cancellation note is required.');
+                            return;
+                          }
+                          if (!selectedRide) return;
+
+                          setCancellingRide(true);
+                          try {
+                            const currentUser = auth.currentUser;
+                            if (!currentUser) return;
+
+                            const rideRef = doc(db, 'rides', selectedRide.id);
+
+                            await runTransaction(db, async (tx) => {
+                              const rideSnap = await tx.get(rideRef);
+                              if (!rideSnap.exists()) throw new Error('Ride no longer exists.');
+
+                              const rideData = rideSnap.data() || {};
+                              if (rideData.ownerId !== currentUser.uid) {
+                                throw new Error('Only the driver can cancel this ride.');
+                              }
+
+                              tx.update(rideRef, {
+                                status: 'cancelled',
+                                cancelledAt: new Date().toISOString(),
+                                cancelledBy: currentUser.uid,
+                                cancellationNote: trimmed,
+                              });
+                            });
+
+                            setCancelRideModalVisible(false);
+                            setDetailsModalVisible(false);
+                            setSelectedRide(null);
+                            setDriverInfo(null);
+                            setDriverVehicle(null);
+                          } catch (e) {
+                            console.error('Error cancelling ride:', e);
+                            alert('Failed to cancel ride. Please try again.');
+                          } finally {
+                            setCancellingRide(false);
+                          }
+                        }}
+                      >
+                        {cancellingRide ? (
+                          <ActivityIndicator size="small" color={colors.white} />
+                        ) : (
+                          <Text style={styles.confirmLeaveButtonText}>Cancel Ride</Text>
+                        )}
+                      </TouchableOpacity>
+                    </View>
+                  </ScrollView>
+                </Pressable>
+              </KeyboardAvoidingView>
+            </Pressable>
           )}
         </View>
       </Modal>


### PR DESCRIPTION
Closes #133 
Closes #129 

## Driver Cancellation Flow + Modal UX Improvements

This PR adds a driver-side cancellation feature within the ride details modal. Drivers can now cancel their hosted rides by providing a mandatory cancellation note, which is stored in Firestore along with cancellation metadata (`status`, `cancelledAt`, `cancelledBy`, and `cancellationNote`). Unlike rider cancellations, no deadline or fee applies to drivers. Firestore updates are handled via a transaction to ensure only the ride owner can cancel.

## Images
<img width="200" height="900" alt="IMG_2499" src="https://github.com/user-attachments/assets/485881f0-821e-42ed-a22e-815824183cc9" />
<img width="200" height="900" alt="IMG_2498" src="https://github.com/user-attachments/assets/13bea998-c032-45dc-8b48-8c0b94f5aaf2" />
<img width="200" height="900" alt="IMG_2497" src="https://github.com/user-attachments/assets/8b1681b5-00c7-41ee-b0a3-a6ccb5374fd0" />
<img width="200" height="900" alt="IMG_2494" src="https://github.com/user-attachments/assets/3a3ca0c0-7f3c-4d78-a6c4-09faacf9cc94" />
