### PR TITLE
Uploading/Choosing Profile Picture

### DIFF
--- a/rideshare-app/app/(tabs)/account/accountpage.js
+++ b/rideshare-app/app/(tabs)/account/accountpage.js
@@ -1,5 +1,6 @@
 import React, { useMemo, useState, useEffect } from 'react';
 import * as ImagePicker from 'expo-image-picker';
+import * as Device from 'expo-device';
 import {
   View,
   Text,
@@ -160,13 +161,27 @@ export default function AccountPage() {
 
   const isIosSimulator = Platform.OS === 'ios' && !Platform.isPad && !Platform.isTV && Platform.constants == null;  
 
-  const chooseImageSource = () => {
+const chooseImageSource = () => {
+  const isIosSimulator = Platform.OS === 'ios' && !Device.isDevice;
+
+  if (isIosSimulator) {
+    // Only Upload option on iOS Simulator
     Alert.alert('Profile Photo', 'Choose a source', [
-      { text: 'Camera', onPress: takePhoto },
       { text: 'Upload', onPress: pickImage },
       { text: 'Cancel', style: 'cancel' },
     ]);
-  };
+    return;
+  }
+
+  // Real devices
+  Alert.alert('Profile Photo', 'Choose a source', [
+    { text: 'Camera', onPress: takePhoto },
+    { text: 'Upload', onPress: pickImage },
+    { text: 'Cancel', style: 'cancel' },
+  ]);
+};
+
+
 const pickImage = async () => {
   const perm = await ImagePicker.requestMediaLibraryPermissionsAsync();
   if (!perm.granted) {


### PR DESCRIPTION
**Do npm install before you test**
Now there is profile picture upload functionality to the Account page (only account page as of now).

Users can:
- Tap the avatar at any time to change their photo
- See the "Change Photo" text only when in **Edit Profile** mode
- Choose between **Camera** or **Upload from gallery**
- Crop and save their image
- See the photo persist after reload

 Simulator vs Real Device Issue

-  iOS Simulator: Camera is not available on teh simulator. Only **Upload from photo library** works.
- Real Phone (Expo Go on ur phone): Both **Camera and Upload** work normally.

closes #143 

Simulator Example:
<img width="403" height="814" alt="Screenshot 2026-02-19 at 10 08 33 PM" src="https://github.com/user-attachments/assets/8389e1db-12ad-4fcd-a32e-9cdf4e247884" />
<img width="423" height="826" alt="Screenshot 2026-02-19 at 10 08 39 PM" src="https://github.com/user-attachments/assets/c627c656-3f6c-43b7-a2dc-7c7ce3dd0fe2" />
<img width="393" height="820" alt="Screenshot 2026-02-19 at 10 08 48 PM" src="https://github.com/user-attachments/assets/63584336-4f78-481e-8d64-145dc0b9082c" />


Expo Go on my phone:
(took a screen recording instead since it was easier, use ucsb email)
https://drive.google.com/file/d/17JUhYLQtZnFR7tt7ZxlkodmkrdYx14e1/view?usp=sharing

