### PR TITLE
cancellation fee notification to riders at 25% of posted price

### DIFF
--- a/rideshare-app/app/(tabs)/home/index.js
+++ b/rideshare-app/app/(tabs)/home/index.js
@@ -141,6 +141,12 @@ export default function Homepage({ user }) {
   const [leavingRide, setLeavingRide] = useState(false);
   const cancellationFee = selectedRide ? Number(selectedRide.price) * 0.25 : 0;
   const cancellationFeeText = formatCurrency(cancellationFee);
+  const cancellationDeadline = selectedRide?.cancellationDeadline
+    ? new Date(selectedRide.cancellationDeadline)
+    : null;
+  const isLateCancellation = Boolean(cancellationDeadline && new Date() > cancellationDeadline);
+  const paymentRecipientName = driverInfo?.name || selectedRide?.ownerName || 'the driver';
+  const paymentHandle = (driverInfo?.payHandle || '').trim();
 
   const [cancelRideModalVisible, setCancelRideModalVisible] = useState(false);
   const [cancellingRide, setCancellingRide] = useState(false);
@@ -585,7 +591,7 @@ export default function Homepage({ user }) {
 
                     <View style={styles.cancellationNotice}>
                       <Text style={styles.cancellationNoticeText}>
-                        ⚠️ Warning: Leaving after the cancellation deadline may result in penalties.
+                        ⚠️ Warning: Leaving after the cancellation deadline incurs a fee (25% of ride price).
                       </Text>
                     </View>
 
@@ -628,18 +634,49 @@ export default function Homepage({ user }) {
           {leaveRideModalVisible && (
             <View style={styles.confirmModalOverlay}>
               <View style={styles.confirmModalContent}>
-                <Text style={styles.confirmModalTitle}>Leave this ride?</Text>
-                <Text style={styles.confirmModalMessage}>
-                  <Text style={{ fontWeight: 'bold' }}>Please review our cancellation policy:</Text>
-                  {'\n\n'}
-                  • Cancellations made after the deadline will incur a {cancellationFeeText} fee
-                  {'\n\n'}
-                  • Fee calculation: 25% of ride price
-                  {'\n\n'}
-                  • If a waitlist exists for this ride, you must rejoin through the waitlist
-                  {'\n\n'}
-                  <Text style={{ fontWeight: 'bold' }}>This action cannot be undone.</Text>
+                <Text style={styles.confirmModalTitle}>
+                  {isLateCancellation ? 'Late Cancellation Notice' : 'Leave this ride?'}
                 </Text>
+
+                {isLateCancellation ? (
+                  <>
+                    <View style={styles.lateDeadlineBanner}>
+                      <Text style={styles.lateDeadlineBannerText}>
+                        You are leaving after the cancellation deadline.
+                      </Text>
+                    </View>
+
+                    <Text style={styles.confirmModalMessage}>
+                      <Text>
+                        A cancellation fee of <Text style={{ fontWeight: 'bold' }}>{cancellationFeeText}</Text> is due (25% of the ride price).
+                      </Text>
+                      {'\n\n'}
+                      <Text>
+                        Please venmo/zelle <Text style={{ fontWeight: 'bold' }}>{paymentRecipientName}</Text>{' '}
+                        {paymentHandle
+                          ? (
+                            <>
+                              at <Text style={{ fontWeight: 'bold' }}>{paymentHandle}</Text>
+                            </>
+                          )
+                          : ' using their listed pay handle'}{' '}
+                        the cancellation fee of <Text style={{ fontWeight: 'bold' }}>{cancellationFeeText}</Text> now.
+                      </Text>
+                      {'\n\n'}
+                      <Text style={{ fontWeight: 'bold' }}>This action cannot be undone.</Text>
+                    </Text>
+                  </>
+                ) : (
+                  <Text style={styles.confirmModalMessage}>
+                    <Text style={{ fontWeight: 'bold' }}>Please review our cancellation policy:</Text>
+                    {'\n\n'}
+                    • Cancellations made after the deadline will incur a fee calculated at 25% of the posted price
+                    {'\n\n'}
+                    • If a waitlist exists for this ride, you must rejoin through the waitlist
+                    {'\n\n'}
+                    <Text style={{ fontWeight: 'bold' }}>This action cannot be undone.</Text>
+                  </Text>
+                )}
                 
                 <View style={styles.confirmModalButtons}>
                   <TouchableOpacity 
@@ -1342,6 +1379,24 @@ const styles = StyleSheet.create({
     marginBottom: 24,
     textAlign: 'left',
     lineHeight: 22,
+  },
+  lateDeadlineBanner: {
+    width: '100%',
+    alignSelf: 'center',
+    backgroundColor: '#fee2e2',
+    borderWidth: 1,
+    borderColor: '#fecaca',
+    borderRadius: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    marginBottom: 14,
+  },
+  lateDeadlineBannerText: {
+    textAlign: 'center',
+    fontSize: 18,
+    lineHeight: 20,
+    fontWeight: '700',
+    color: '#991b1b',
   },
   confirmModalButtons: {
     flexDirection: 'row',


### PR DESCRIPTION
**Closes:**
#137 
#140 

This feature change shows the user what fee they may incur if it is past the cancellation deadline. 

If the cancellation deadline has **not** yet passed, the user will see the cancellation policy before leaving the ride: 


<img width="590" height="1278" alt="IMG_1921" src="https://github.com/user-attachments/assets/a5964e33-d557-4228-8be1-e5f9003e7bef" />



If the cancellation deadline **has** passed, the user will see the price they must pay before leaving the ride (25% of posted price). UI makes it clear to user they will need to pay a fee. **Note: this feature is currently operating on "honor code":** 


<img width="590" height="1278" alt="IMG_1920" src="https://github.com/user-attachments/assets/032892cb-ef0e-4f64-bdfd-03de1ec4e34b" />
