### PR TITLE
enforce ride input limits and improve UI validation feedback

### DIFF
--- a/rideshare-app/app/(tabs)/home/joinpage.js
+++ b/rideshare-app/app/(tabs)/home/joinpage.js
@@ -350,7 +350,11 @@ export default function JoinPage() {
             <View style={[styles.driverIcon, disabled && styles.driverIconDisabled]}>
               <Text style={[styles.driverIconText, disabled && styles.textDisabled]}>👤</Text>
             </View>
-            <Text style={[styles.driverName, disabled && styles.textDisabled]}>
+            <Text 
+              style={[styles.driverName, disabled && styles.textDisabled]}
+              numberOfLines={1}
+              ellipsizeMode="tail"
+            >
               {item.ownerName}
             </Text>
           </View>
@@ -831,6 +835,8 @@ const styles = StyleSheet.create({
   driverNameSection: {
     flexDirection: "row",
     alignItems: "center",
+    flex: 1,
+    minWidth: 0,
   },
   tagBox: {
     width: 16,
@@ -853,11 +859,13 @@ const styles = StyleSheet.create({
     fontSize: 22,
   },
   driverName: {
+    flexShrink: 1,
     fontSize: 18,
     fontWeight: "bold",
     color: colors.textPrimary,
   },
   ridePrice: {
+    flexShrink: 0,
     fontSize: 24,
     fontWeight: "bold",
     color: colors.primary,


### PR DESCRIPTION
This PR adds stronger ride-creation validation and UI safety for long display names

Changes
* Added a max ride price limit of $999.99 on the host/create-ride flow.
* Added a max seats limit of 50 on the host/create-ride flow.
* Added submit-time validation with alerts to block invalid ride creation.
* Added inline seats validation feedback (red text) when typed seats exceed 50.
* Updated Join Rides card UI to prevent long driver names from pushing price off-screen:
   * name now truncates with ellipsis (...)
   * layout keeps ride price visible.