### PR TITLE
click on profiles from home and join page

### DIFF
--- a/rideshare-app/app/(tabs)/_layout.js
+++ b/rideshare-app/app/(tabs)/_layout.js
@@ -16,6 +16,7 @@ export default function TabsLayout() {
   }
 
   const isChatScreen = segments.includes("messages") && segments.includes("chat");
+  const isProfilePage = segments.includes("account") && segments.includes("profilepage");
 
   return (
     <View style={commonStyles.container}>
@@ -32,7 +33,7 @@ export default function TabsLayout() {
         </Tabs>
       </View>
 
-      {!isChatScreen && <NavBar />}
+      {!isChatScreen && !isProfilePage && <NavBar />}
     </View>
   );
 }

--- a/rideshare-app/app/(tabs)/account/profilepage.js
+++ b/rideshare-app/app/(tabs)/account/profilepage.js
@@ -8,6 +8,7 @@ import {
   ScrollView,
   TouchableOpacity,
   ActivityIndicator,
+  Image,
 } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
 import { colors } from '../../../ui/styles/colors';
@@ -52,6 +53,7 @@ export default function ProfileViewPage() {
             clubs: data.clubs || '',
             bio: data.bio || '',
             payHandle: data.payHandle || '',
+            photoURL: data.photoURL || null,
             vehicleMake: primaryVehicle.make || '',
             vehicleModel: primaryVehicle.model || '',
             vehiclePlate: primaryVehicle.plate || '',
@@ -128,7 +130,11 @@ export default function ProfileViewPage() {
           {/* Avatar + Name */}
           <View style={styles.headerRow}>
             <View style={styles.avatar}>
-              <Text style={styles.avatarText}>{initials}</Text>
+              {profile.photoURL ? (
+                <Image source={{ uri: profile.photoURL }} style={styles.avatarImage} />
+              ) : (
+                <Text style={styles.avatarText}>{initials}</Text>
+              )}
             </View>
             <View style={styles.headerText}>
               <Text style={styles.name}>{profile.name}</Text>
@@ -194,10 +200,10 @@ export default function ProfileViewPage() {
             </View>
           ) : null}
 
-          {/* Bio */}
+          {/* Fun Fact */}
           {profile.bio ? (
             <View style={styles.section}>
-              <Text style={styles.sectionTitle}>About</Text>
+              <Text style={styles.sectionTitle}>Fun Fact</Text>
               <View style={styles.field}>
                 <Text style={styles.label}>Bio</Text>
                 <Text style={styles.bioValue}>{profile.bio}</Text>
@@ -209,12 +215,16 @@ export default function ProfileViewPage() {
           {hasVehicle ? (
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>Vehicle</Text>
-              {profile.vehicleMake || profile.vehicleModel ? (
+              {profile.vehicleMake ? (
                 <View style={styles.field}>
-                  <Text style={styles.label}>Vehicle</Text>
-                  <Text style={styles.value}>
-                    {[profile.vehicleMake, profile.vehicleModel].filter(Boolean).join(' ')}
-                  </Text>
+                  <Text style={styles.label}>Vehicle Make</Text>
+                  <Text style={styles.value}>{profile.vehicleMake}</Text>
+                </View>
+              ) : null}
+              {profile.vehicleModel ? (
+                <View style={styles.field}>
+                  <Text style={styles.label}>Vehicle Model</Text>
+                  <Text style={styles.value}>{profile.vehicleModel}</Text>
                 </View>
               ) : null}
               {profile.vehiclePlate ? (
@@ -309,6 +319,11 @@ const styles = StyleSheet.create({
     color: '#FFFFFF',
     fontSize: 22,
     fontWeight: '700',
+  },
+  avatarImage: {
+    width: 64,
+    height: 64,
+    borderRadius: 32,
   },
   name: {
     fontSize: 20,

--- a/rideshare-app/app/(tabs)/home/index.js
+++ b/rideshare-app/app/(tabs)/home/index.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from 'react';
-import { router } from "expo-router";
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { router, useFocusEffect } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
 import {
   StyleSheet,
@@ -152,6 +152,16 @@ export default function Homepage({ user }) {
   const [cancellingRide, setCancellingRide] = useState(false);
   const [cancelNote, setCancelNote] = useState('');
   const [cancelNoteError, setCancelNoteError] = useState(''); 
+  const reopenModalRef = useRef(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (reopenModalRef.current) {
+        reopenModalRef.current = false;
+        setDetailsModalVisible(true);
+      }
+    }, [])
+  );
 
   useEffect(() => {
     const currentUser = auth.currentUser;
@@ -469,7 +479,17 @@ export default function Homepage({ user }) {
                   <View style={styles.modalDriverIcon}>
                     <Text style={styles.modalDriverIconText}>👤</Text>
                   </View>
-                  <Text style={styles.modalDriverTitle}>{selectedRide.ownerName}</Text>
+                  {selectedRide.ownerId !== auth.currentUser?.uid ? (
+                    <TouchableOpacity onPress={() => {
+                      setDetailsModalVisible(false);
+                      reopenModalRef.current = true;
+                      router.push({ pathname: '/(tabs)/account/profilepage', params: { userId: selectedRide.ownerId } });
+                    }} activeOpacity={0.7}>
+                      <Text style={styles.modalDriverTitle}>{selectedRide.ownerName}</Text>
+                    </TouchableOpacity>
+                  ) : (
+                    <Text style={styles.modalDriverTitle}>{selectedRide.ownerName}</Text>
+                  )}
                 </View>
 
                 <Text style={styles.modalSectionTitle}>Ride Info</Text>

--- a/rideshare-app/app/(tabs)/home/joinpage.js
+++ b/rideshare-app/app/(tabs)/home/joinpage.js
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { useRouter } from "expo-router";
+import React, { useEffect, useState, useRef, useCallback } from "react";
+import { useRouter, useFocusEffect } from "expo-router";
 import {
   View,
   Text,
@@ -70,6 +70,16 @@ export default function JoinPage() {
   
   const [showFilterModal, setShowFilterModal] = useState(false);
   const [selectedTags, setSelectedTags] = useState(new Set());
+  const reopenModalRef = useRef(false);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (reopenModalRef.current) {
+        reopenModalRef.current = false;
+        setModalVisible(true);
+      }
+    }, [])
+  );
 
   useEffect(() => {
     if (!user?.uid) return;
@@ -631,7 +641,13 @@ export default function JoinPage() {
                       <View style={styles.modalDriverIcon}>
                         <Text style={styles.modalDriverIconText}>👤</Text>
                       </View>
-                      <Text style={styles.modalDriverTitle}>{selectedRide.ownerName}</Text>
+                      <TouchableOpacity onPress={() => {
+                        setModalVisible(false);
+                        reopenModalRef.current = true;
+                        router.push({ pathname: '/(tabs)/account/profilepage', params: { userId: selectedRide.ownerId } });
+                      }} activeOpacity={0.7}>
+                        <Text style={styles.modalDriverTitle}>{selectedRide.ownerName}</Text>
+                      </TouchableOpacity>
                     </View>
 
                     <Text style={styles.modalSectionTitle}>Ride Info</Text>

--- a/rideshare-app/app/(tabs)/messages/chat.js
+++ b/rideshare-app/app/(tabs)/messages/chat.js
@@ -207,12 +207,11 @@ export default function ChatScreen() {
     return (String(name).trim().charAt(0) || 'U').toUpperCase();
   };
 
-  const navigateToProfile = (userId) => {
+  const openProfilePopup = (userId) => {
+    const myUid = auth.currentUser?.uid;
+    if (!userId || userId === myUid) return;
     setShowParticipants(false);
-    router.push({
-      pathname: '/(tabs)/account/profilepage',
-      params: { userId, conversationId },
-    });
+    router.push({ pathname: '/(tabs)/account/profilepage', params: { userId } });
   };
 
   const handleHeaderPress = () => {
@@ -221,7 +220,7 @@ export default function ChatScreen() {
     const otherParticipants = participants.filter((uid) => uid !== myUid);
 
     if (otherParticipants.length === 1) {
-      navigateToProfile(otherParticipants[0]);
+      openProfilePopup(otherParticipants[0]);
     } else if (otherParticipants.length > 1) {
       setShowParticipants(true);
     }
@@ -258,11 +257,13 @@ export default function ChatScreen() {
         ]}
       >
         {!isMyMessage && isFirstInGroup && (
-          <View style={styles.msgAvatar}>
-            <Text style={styles.msgAvatarText}>
-              {getAvatarInitial(item.senderId, senderDisplayName)}
-            </Text>
-          </View>
+          <TouchableOpacity onPress={() => openProfilePopup(item.senderId)} activeOpacity={0.7}>
+            <View style={styles.msgAvatar}>
+              <Text style={styles.msgAvatarText}>
+                {getAvatarInitial(item.senderId, senderDisplayName)}
+              </Text>
+            </View>
+          </TouchableOpacity>
         )}
 
         {!isMyMessage && !isFirstInGroup && (
@@ -435,11 +436,25 @@ export default function ChatScreen() {
               {(conversationData?.participants || []).map((uid) => {
                 const isMe = uid === auth.currentUser?.uid;
                 const name = conversationData?.participantNames?.[uid] || 'Unknown';
+                if (isMe) {
+                  return (
+                    <View key={uid} style={styles.participantRow}>
+                      <View style={styles.participantAvatar}>
+                        <Text style={styles.participantAvatarText}>
+                          {(name.charAt(0) || 'U').toUpperCase()}
+                        </Text>
+                      </View>
+                      <Text style={styles.participantName}>
+                        {name} (You)
+                      </Text>
+                    </View>
+                  );
+                }
                 return (
                   <TouchableOpacity
                     key={uid}
                     style={styles.participantRow}
-                    onPress={() => navigateToProfile(uid)}
+                    onPress={() => openProfilePopup(uid)}
                     activeOpacity={0.6}
                   >
                     <View style={styles.participantAvatar}>
@@ -448,7 +463,7 @@ export default function ChatScreen() {
                       </Text>
                     </View>
                     <Text style={styles.participantName}>
-                      {name}{isMe ? ' (You)' : ''}
+                      {name}
                     </Text>
                     <Ionicons name="chevron-forward" size={18} color={colors.textSecondary} />
                   </TouchableOpacity>


### PR DESCRIPTION
closes #178 

This PR introduces a new interaction that allows users to tap on user names across the app (chat page, home page, join page) to view a full profile page, without losing their place in the app. The feature supports navigation to a profile page and restores the user’s previous context when they return.


<img width="360" height="770" alt="image" src="https://github.com/user-attachments/assets/c4ae3d57-fce5-4a5a-ba80-b7be17e63f97" />
<img width="342" height="763" alt="image" src="https://github.com/user-attachments/assets/1632d916-9298-4937-8716-4f58c23f3519" />
