### PR TITLE
Drivers now see a start button (no functionality)

### DIFF
--- a/rideshare-app/app/(tabs)/home/index.js
+++ b/rideshare-app/app/(tabs)/home/index.js
@@ -76,12 +76,54 @@ function RideList({ rides, emptyText, isHosted = false, onViewDetails = null }) 
               </Text>
             </View>
           </View>
-          <TouchableOpacity 
-            style={styles.joinedViewDetailsButton}
-            onPress={() => onViewDetails && onViewDetails(item)}
-          >
-            <Text style={styles.joinedViewDetailsText}>View Details</Text>
-          </TouchableOpacity>
+          {isHosted ? (
+            <View style={styles.startRideRow}>
+              <TouchableOpacity 
+                style={[styles.joinedViewDetailsButton, { flex: 1 }]}
+                onPress={() => onViewDetails && onViewDetails(item)}
+              >
+                <Text style={styles.joinedViewDetailsText}>View Details</Text>
+              </TouchableOpacity>
+              {new Date() >= new Date(item.rideDate) ? (
+                <>
+                  <TouchableOpacity
+                    style={[styles.startRideButtonActive, { flex: 1 }]}
+                    onPress={() => {}}
+                  >
+                    <Text style={styles.startRideTextActive}>Start Ride</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={styles.startRideInfoButton}
+                    onPress={() => alert('Start Ride is now available! Tap to begin your ride.')}
+                  >
+                    <Ionicons name="information-circle-outline" size={20} color={colors.accent} />
+                  </TouchableOpacity>
+                </>
+              ) : (
+                <>
+                  <TouchableOpacity
+                    style={[styles.startRideButtonDisabled, { flex: 1 }]}
+                    onPress={() => alert('Start Ride will be available once the scheduled ride time begins.')}
+                  >
+                    <Text style={styles.startRideTextDisabled}>Start Ride</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={styles.startRideInfoButton}
+                    onPress={() => alert('Start Ride will be available once the scheduled ride time begins.')}
+                  >
+                    <Ionicons name="information-circle-outline" size={20} color="#555" />
+                  </TouchableOpacity>
+                </>
+              )}
+            </View>
+          ) : (
+            <TouchableOpacity 
+              style={styles.joinedViewDetailsButton}
+              onPress={() => onViewDetails && onViewDetails(item)}
+            >
+              <Text style={styles.joinedViewDetailsText}>View Details</Text>
+            </TouchableOpacity>
+          )}
         </View>
       )}
     />
@@ -180,7 +222,8 @@ export default function Homepage({ user }) {
           id: doc.id,
           ...doc.data(),
         }))
-        .filter((ride) => ride.status !== 'cancelled' && ride.status !== 'canceled');
+        .filter((ride) => ride.status !== 'cancelled' && ride.status !== 'canceled')
+        .sort((a, b) => new Date(a.rideDate) - new Date(b.rideDate));
       setHostedRides(rides);
       setLoading(false);
     }, (error) => {
@@ -380,7 +423,7 @@ export default function Homepage({ user }) {
                 <RideList
                   rides={hostedRides}
                   emptyText={"No hosted rides yet.\nTap Host to create a ride."}
-                  isHosted={false}
+                  isHosted={true}
                   onViewDetails={async (ride) => {
                     setSelectedRide(ride);
                     setDetailsModalVisible(true);
@@ -1154,7 +1197,7 @@ const styles = StyleSheet.create({
   },
   joinedCardRight: {
     flex: 1,
-    marginLeft: 16,
+    marginLeft: -32,
   },
   joinedCardLabel: {
     fontSize: 12,
@@ -1188,6 +1231,45 @@ const styles = StyleSheet.create({
   },
   joinedViewDetailsText: {
     color: colors.accent,
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  startRideButtonDisabled: {
+    backgroundColor: '#d4d4d4',
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: '#bbb',
+    alignItems: 'center',
+    opacity: 0.6,
+  },
+  startRideTextDisabled: {
+    color: '#555',
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  startRideRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 8,
+    gap: 8,
+  },
+  startRideInfoButton: {
+    padding: 4,
+  },
+  startRideButtonActive: {
+    backgroundColor: colors.accent,
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: colors.accent,
+    alignItems: 'center',
+  },
+  startRideTextActive: {
+    color: '#fff',
     fontSize: 13,
     fontWeight: '600',
   },


### PR DESCRIPTION
Closes #261 

**Start Ride Button**
- Added a "Start Ride" button on host ride cards (grayed out / disabled by default)
- Button activates (changes to teal accent color) when the scheduled ride time is reached
- Added ℹ️ info icon below the button; tapping it shows an alert explaining when Start Ride becomes available
- Tapping the grayed-out Start Ride button also shows the info alert
- When active, the ℹ️ alert updates to indicate the ride can now be started
- No backend functionality wired up yet — UI only

**Host Card Sorting**
- Hosted rides are now sorted by departure time, soonest ride on top
- Layout Adjustments
Shifted "To:" destination text further left on ride cards for better alignment
"View Details" and "Start Ride" buttons display side by side on hosted ride cards

**Acceptance Criteria**
- [ ] Host ride cards display a "Start Ride" button next to "View Details"
 - [ ] "Start Ride" button is grayed out and disabled before the scheduled ride time
 - [ ] Tapping the grayed-out button shows an info alert explaining it will activate at ride time
 - [ ] An ℹ️ icon appears next to the button; tapping it shows the same info alert
 - [ ] At or after the scheduled ride time, the button changes to the active teal color
- [ ] The active button has no backend functionality yet (UI only)
- [ ] Hosted rides are sorted by departure time, soonest first
- [ ] "View Details" and "Start Ride" buttons appear side by side on host cards
- [ ] "To:" destination text is shifted left for better alignment on ride cards

<img width="250" height="1266" alt="IMG_1738" src="https://github.com/user-attachments/assets/61ab74f8-17fe-45e3-a471-4d24c79ee5a9" />
<img width="250" height="1266" alt="IMG_1737" src="https://github.com/user-attachments/assets/2ab9bcf5-ad25-42cf-b086-6506712c8293" />
<img width="250" height="1266" alt="IMG_1736" src="https://github.com/user-attachments/assets/bee323b0-6ebb-437b-9153-6fb829d1d036" />
