### PR TITLE
added waitlist logic

### DIFF
--- a/rideshare-app/.gitignore
+++ b/rideshare-app/.gitignore
@@ -69,3 +69,4 @@ node_modules/
 .dataconnect
 
 functions/.env
+functions/.secret.local

--- a/rideshare-app/app/(tabs)/home/index.js
+++ b/rideshare-app/app/(tabs)/home/index.js
@@ -19,7 +19,8 @@ import {
   Alert,
 } from 'react-native';
 import { collection, query, where, onSnapshot, doc, getDoc, getDocs, updateDoc, runTransaction, writeBatch, addDoc, serverTimestamp } from 'firebase/firestore';
-import { auth, db } from '../../../src/firebase';
+import { auth, db, functions } from '../../../src/firebase';
+import { httpsCallable } from 'firebase/functions';
 import { colors } from '../../../ui/styles/colors';
 import { commonStyles } from '../../../ui/styles/commonStyles';
 import { useActiveRide } from '../../../src/context/ActiveRideContext';
@@ -805,33 +806,11 @@ export default function Homepage({ user }) {
                         const currentUser = auth.currentUser;
                         if (!currentUser) return;
 
-                        const rideRef = doc(db, 'rides', selectedRide.id);
-                        const joinRef = doc(db, 'rides', selectedRide.id, 'joins', currentUser.uid);
+                        await currentUser.getIdToken(true);
 
-                        await runTransaction(db, async (tx) => {
-                          const [rideSnap, joinSnap] = await Promise.all([
-                            tx.get(rideRef),
-                            tx.get(joinRef),
-                          ]);
+                        const leaveRideAndPromote = httpsCallable(functions, 'leaveRideAndPromote');
+                        await leaveRideAndPromote({ rideId: selectedRide.id });
 
-                          if (!rideSnap.exists()) throw new Error('Ride no longer exists.');
-                          if (!joinSnap.exists()) throw new Error('You have not joined this ride.');
-
-                          const rideData = rideSnap.data() || {};
-                          const seatsNumRaw = Number(rideData.seats);
-                          const seatsNum = Number.isFinite(seatsNumRaw) ? seatsNumRaw : 0;
-                          const totalSeatsRaw = Number(rideData.total_seats ?? seatsNum);
-                          const totalSeats = Number.isFinite(totalSeatsRaw) ? totalSeatsRaw : null;
-                          const nextSeats = totalSeats !== null
-                            ? Math.min(seatsNum + 1, totalSeats)
-                            : seatsNum + 1;
-
-                          tx.update(rideRef, {
-                            seats: nextSeats,
-                            total_seats: rideData.total_seats ?? seatsNum,
-                          });
-                          tx.delete(joinRef);
-                        });
                         // Send notifications
                         try {
                           const now = new Date();

--- a/rideshare-app/app/(tabs)/home/joinpage.js
+++ b/rideshare-app/app/(tabs)/home/joinpage.js
@@ -25,6 +25,8 @@ import {
   onSnapshot,
   runTransaction,
   serverTimestamp,
+  setDoc,
+  deleteDoc,
 } from "firebase/firestore";
 import { httpsCallable } from "firebase/functions";
 import { functions } from "../../../src/firebase";
@@ -75,6 +77,7 @@ export default function JoinPage() {
   const [isJoining, setIsJoining] = useState(false);
 
   const [joinedRideIds, setJoinedRideIds] = useState(new Set());
+  const [joinedLoaded, setJoinedLoaded] = useState(false);
   
   const [showFilterModal, setShowFilterModal] = useState(false);
   const [selectedTags, setSelectedTags] = useState(new Set());
@@ -84,6 +87,42 @@ export default function JoinPage() {
   const reopenModalRef = useRef(false);
 
   const [ownerPhotos, setOwnerPhotos] = useState({});
+  const [waitlistedRideIds, setWaitlistedRideIds] = useState(new Set());
+  const [waitlistPositions, setWaitlistPositions] = useState({});
+  const [waitlistModalVisible, setWaitlistModalVisible] = useState(false);
+  const [waitlistModalRide, setWaitlistModalRide] = useState(null);
+  const [waitlistConfirmVisible, setWaitlistConfirmVisible] = useState(false);
+  const [waitlistConfirmRide, setWaitlistConfirmRide] = useState(null);
+  const [isJoiningWaitlist, setIsJoiningWaitlist] = useState(false);
+
+  const openWaitlistModal = (ride) => {
+    setWaitlistModalRide(ride);
+    setWaitlistModalVisible(true);
+  };
+
+  const closeWaitlistModal = () => {
+    setWaitlistModalVisible(false);
+    setTimeout(() => setWaitlistModalRide(null), 300);
+  };
+
+  const openWaitlistConfirm = (ride) => {
+    if (!user?.uid) {
+      Alert.alert("Not signed in", "Please sign in to join the waitlist.");
+      return;
+    }
+    if (joinedRideIds.has(ride.id)) return;
+    if (isDepartureTooSoon(ride)) {
+      Alert.alert("Too Late", "You cannot join the waitlist within 24 hours of departure.");
+      return;
+    }
+    setWaitlistConfirmRide(ride);
+    setWaitlistConfirmVisible(true);
+  };
+
+  const closeWaitlistConfirm = () => {
+    setWaitlistConfirmVisible(false);
+    setWaitlistConfirmRide(null);
+  };
 
   useFocusEffect(
     useCallback(() => {
@@ -117,7 +156,8 @@ export default function JoinPage() {
             (ride) =>
               ride.ownerId !== user.uid &&
               ride.status !== "cancelled" &&
-              ride.status !== "canceled"
+              ride.status !== "canceled" &&
+              new Date(ride.rideDate).getTime() > Date.now()
           );
 
         setRides(ridesData);
@@ -147,6 +187,7 @@ export default function JoinPage() {
   useEffect(() => {
     if (!user?.uid) {
       setJoinedRideIds(new Set());
+      setJoinedLoaded(true);
       return;
     }
 
@@ -166,10 +207,52 @@ export default function JoinPage() {
       } catch (e) {
         console.warn("Failed to compute joinedRideIds:", e?.message ?? e);
         setJoinedRideIds(new Set());
+      } finally {
+        setJoinedLoaded(true);
       }
     });
 
     return () => unsub();
+  }, [user?.uid]);
+
+  // Track waitlisted rides and positions
+  useEffect(() => {
+    if (!user?.uid) {
+      setWaitlistedRideIds(new Set());
+      setWaitlistPositions({});
+      return;
+    }
+
+    const unsub2 = onSnapshot(collection(db, "rides"), async (snap) => {
+      try {
+        const ids = new Set();
+        const positions = {};
+
+        await Promise.all(
+          snap.docs.map(async (rideDoc) => {
+            const rideId = rideDoc.id;
+            const waitlistSnap = await getDoc(doc(db, "rides", rideId, "waitlist", user.uid));
+            if (waitlistSnap.exists()) {
+              ids.add(rideId);
+              // Compute position by counting how many waitlist entries have an earlier joinedAt
+              const allWaitlistSnap = await getDocs(
+                query(collection(db, "rides", rideId, "waitlist"), orderBy("joinedAt", "asc"))
+              );
+              const allWaitlist = allWaitlistSnap.docs.map((d) => d.id);
+              const pos = allWaitlist.indexOf(user.uid);
+              positions[rideId] = pos >= 0 ? pos + 1 : null;
+            }
+          })
+        );
+
+        setWaitlistedRideIds(ids);
+        setWaitlistPositions(positions);
+      } catch (e) {
+        console.warn("Failed to compute waitlist info:", e?.message ?? e);
+      }
+    });
+
+    return () => unsub2();
   }, [user?.uid]);
 
   const fetchRides = async () => {
@@ -185,7 +268,8 @@ export default function JoinPage() {
         if (
           ride.ownerId !== user?.uid &&
           ride.status !== "cancelled" &&
-          ride.status !== "canceled"
+          ride.status !== "canceled" &&
+          new Date(ride.rideDate).getTime() > Date.now()
         ) {
           ridesData.push({
             ...ride,
@@ -307,6 +391,105 @@ export default function JoinPage() {
     return Number.isFinite(n) ? n : 0;
   };
 
+  const isDepartureTooSoon = (ride) => {
+    if (!ride?.rideDate) return false;
+    const departure = new Date(ride.rideDate).getTime();
+    const now = Date.now();
+    const twentyFourHours = 24 * 60 * 60 * 1000;
+    return departure - now < twentyFourHours;
+  };
+
+  const handleJoinWaitlist = async (ride) => {
+    if (!user?.uid) return;
+    try {
+      setIsJoiningWaitlist(true);
+
+      const waitlistRef = doc(db, "rides", ride.id, "waitlist", user.uid);
+      const existing = await getDoc(waitlistRef);
+      if (existing.exists()) {
+        closeWaitlistConfirm();
+        return;
+      }
+
+      const createWaitlistHold = httpsCallable(functions, "createWaitlistHold");
+      const { data } = await createWaitlistHold({
+        amount: Math.round(Number(ride.price) * 100),
+        rideId: ride.id,
+      });
+      const { clientSecret, paymentIntentId } = data;
+
+      const { error: initError } = await initPaymentSheet({
+        merchantDisplayName: STRIPE_CONFIG.MERCHANT_NAME,
+        paymentIntentClientSecret: clientSecret,
+      });
+
+      if (initError) throw new Error(initError.message);
+
+      const { error: paymentError } = await presentPaymentSheet();
+
+      if (paymentError) {
+        if (paymentError.code === "Canceled") {
+          setIsJoiningWaitlist(false);
+          return;
+        }
+        throw new Error(paymentError.message);
+      }
+
+      await setDoc(waitlistRef, {
+        riderId: user.uid,
+        riderEmail: user.email ?? "",
+        joinedAt: serverTimestamp(),
+        paymentIntentId: paymentIntentId,
+      });
+      setWaitlistedRideIds((prev) => new Set(prev).add(ride.id));
+      const allWaitlistSnap = await getDocs(collection(db, "rides", ride.id, "waitlist"));
+      const sorted = allWaitlistSnap.docs
+        .sort((a, b) => (a.data().joinedAt?.toMillis?.() ?? 0) - (b.data().joinedAt?.toMillis?.() ?? 0))
+        .map((d) => d.id);
+      const pos = sorted.indexOf(user.uid);
+      setWaitlistPositions((prev) => ({ ...prev, [ride.id]: pos >= 0 ? pos + 1 : 1 }));
+      closeWaitlistConfirm();
+    } catch (e) {
+      console.error("waitlist error:", e);
+      Alert.alert("Error", e?.message || "Could not join waitlist.");
+    } finally {
+      setIsJoiningWaitlist(false);
+    }
+  };
+
+  const handleLeaveWaitlist = async (ride) => {
+    try {
+      const waitlistRef = doc(db, "rides", ride.id, "waitlist", user.uid);
+      const waitlistSnap = await getDoc(waitlistRef);
+      const paymentIntentId = waitlistSnap.exists() ? waitlistSnap.data().paymentIntentId : null;
+
+      await deleteDoc(waitlistRef);
+
+      if (paymentIntentId) {
+        try {
+          const cancelWaitlistHold = httpsCallable(functions, "cancelWaitlistHold");
+          await cancelWaitlistHold({ paymentIntentId });
+        } catch (cancelErr) {
+          console.warn("Failed to cancel hold:", cancelErr?.message);
+        }
+      }
+
+      setWaitlistedRideIds((prev) => {
+        const next = new Set(prev);
+        next.delete(ride.id);
+        return next;
+      });
+      setWaitlistPositions((prev) => {
+        const next = { ...prev };
+        delete next[ride.id];
+        return next;
+      });
+    } catch (e) {
+      console.error("leave waitlist error:", e);
+      Alert.alert("Error", e?.message || "Could not leave waitlist.");
+    }
+  };
+
   const openJoinConfirm = (ride) => {
     const alreadyJoined = joinedRideIds.has(ride.id);
     const soldOut = Number(ride.seats) <= 0;
@@ -316,7 +499,7 @@ export default function JoinPage() {
       return;
     }
     if (soldOut) {
-      Alert.alert("Sold out", "No seats left for this ride.");
+      // Don't show "Sold out" alert — waitlist button handles this
       return;
     }
 
@@ -343,7 +526,8 @@ export default function JoinPage() {
     try {
       setIsJoining(true);
 
-      // Call Cloud Function to create PaymentIntent
+      await user.getIdToken(true);
+
       const createPaymentIntent = httpsCallable(functions, "createPaymentIntent");
       const { data } = await createPaymentIntent({
         amount: Math.round(Number(confirmRide.price) * 100), // convert dollars to cents
@@ -432,6 +616,11 @@ export default function JoinPage() {
         Alert.alert("Already joined", "You already joined this ride.");
         return;
       }
+      if (msg.toLowerCase().includes("unauthenticated") || e?.code === "functions/unauthenticated") {
+        closeJoinConfirm();
+        Alert.alert("Session Expired", "Please sign in again to join a ride.");
+        return;
+      }
       console.error("join error:", e);
       Alert.alert("Error", msg || "Could not join ride.");
     } finally {
@@ -442,12 +631,14 @@ export default function JoinPage() {
   const renderRideCard = ({ item }) => {
     const alreadyJoined = joinedRideIds.has(item.id);
     const soldOut = Number(item.seats) <= 0;
-    const disabled = alreadyJoined || soldOut;
+    const onWaitlist = waitlistedRideIds.has(item.id);
+    const disabled = alreadyJoined || (soldOut && !onWaitlist);
     const tagColor = item.tag ? tagColors[item.tag] : null;
+    const tooSoon = isDepartureTooSoon(item);
 
     return (
       <TouchableOpacity
-        style={[styles.rideCard, disabled && styles.rideCardDisabled]}
+        style={[styles.rideCard, (alreadyJoined || soldOut) && styles.rideCardDisabled]}
         onPress={() => handleRidePress(item)}
         activeOpacity={0.85}
       >
@@ -513,28 +704,76 @@ export default function JoinPage() {
           </View>
         </View>
 
-        {/* Bottom row: View details and JOIN/JOINED/SOLD OUT button */}
+        {/* Bottom row: View details and JOIN/JOINED/WAITLIST button */}
         <View style={styles.cardBottomRow}>
           <TouchableOpacity
-            style={[styles.viewDetailsButton, disabled && styles.viewDetailsButtonDisabled]}
+            style={[styles.viewDetailsButton, (alreadyJoined) && styles.viewDetailsButtonDisabled]}
             onPress={() => handleRidePress(item)}
             activeOpacity={0.85}
           >
-            <Text style={[styles.viewDetailsButtonText, disabled && styles.textDisabled]}>
+            <Text style={[styles.viewDetailsButtonText, (alreadyJoined) && styles.textDisabled]}>
               View Details
             </Text>
           </TouchableOpacity>
 
-          <TouchableOpacity
-            style={[styles.joinButton, disabled && styles.joinButtonDisabled]}
-            onPress={() => openJoinConfirm(item)}
-            disabled={disabled}
-            activeOpacity={0.85}
-          >
-            <Text style={[styles.joinButtonText, disabled && styles.joinButtonTextDisabled]}>
-              {alreadyJoined ? "Joined" : soldOut ? "Sold Out" : "Join"}
-            </Text>
-          </TouchableOpacity>
+          <View style={styles.waitlistButtonGroup}>
+            {alreadyJoined ? (
+              <TouchableOpacity
+                style={[styles.joinButton, styles.joinButtonDisabled]}
+                disabled
+                activeOpacity={0.85}
+              >
+                <Text style={[styles.joinButtonText, styles.joinButtonTextDisabled]}>Joined</Text>
+              </TouchableOpacity>
+            ) : soldOut && joinedLoaded ? (
+              onWaitlist ? (
+                <TouchableOpacity
+                  style={[styles.joinButton, styles.waitlistActiveButton]}
+                  onPress={() => openWaitlistModal(item)}
+                  activeOpacity={0.85}
+                >
+                  <View style={styles.waitlistedInner}>
+                    <Text style={styles.waitlistActiveButtonText}>Waitlisted</Text>
+                    <Text style={styles.waitlistInlineInfo}>ⓘ</Text>
+                  </View>
+                </TouchableOpacity>
+              ) : !tooSoon ? (
+                <TouchableOpacity
+                  style={[styles.joinButton, styles.waitlistButton]}
+                  onPress={() => openWaitlistConfirm(item)}
+                  activeOpacity={0.85}
+                >
+                  <Text style={[styles.joinButtonText, styles.waitlistButtonText]}>
+                    Join Waitlist
+                  </Text>
+                </TouchableOpacity>
+              ) : (
+                <TouchableOpacity
+                  style={[styles.joinButton, styles.joinButtonDisabled]}
+                  disabled
+                  activeOpacity={0.85}
+                >
+                  <Text style={[styles.joinButtonText, styles.joinButtonTextDisabled]}>Sold Out</Text>
+                </TouchableOpacity>
+              )
+            ) : soldOut && !joinedLoaded ? (
+              <TouchableOpacity
+                style={[styles.joinButton, styles.joinButtonDisabled]}
+                disabled
+                activeOpacity={0.85}
+              >
+                <Text style={[styles.joinButtonText, styles.joinButtonTextDisabled]}>...</Text>
+              </TouchableOpacity>
+            ) : (
+              <TouchableOpacity
+                style={styles.joinButton}
+                onPress={() => openJoinConfirm(item)}
+                activeOpacity={0.85}
+              >
+                <Text style={styles.joinButtonText}>Join</Text>
+              </TouchableOpacity>
+            )}
+          </View>
         </View>
       </TouchableOpacity>
     );
@@ -604,6 +843,121 @@ export default function JoinPage() {
             onRefresh={fetchRides}
           />
         )}
+
+        {/* Waitlist Confirm Modal */}
+        <Modal
+          animationType="fade"
+          transparent
+          visible={waitlistConfirmVisible}
+          onRequestClose={closeWaitlistConfirm}
+        >
+          <View style={styles.modalOverlay}>
+            <View style={styles.confirmCard}>
+              <Text style={styles.confirmTitle}>Join Waitlist</Text>
+
+              {waitlistConfirmRide && (
+                <>
+                  <View style={styles.confirmRow}>
+                    <Text style={styles.confirmLabel}>Driver</Text>
+                    <Text style={styles.confirmValue}>{waitlistConfirmRide.ownerName}</Text>
+                  </View>
+
+                  <View style={styles.confirmRow}>
+                    <Text style={styles.confirmLabel}>When</Text>
+                    <Text style={styles.confirmValue}>
+                      {formatDate(waitlistConfirmRide.rideDate)} • {formatTime(waitlistConfirmRide.rideDate)}
+                    </Text>
+                  </View>
+
+                  <View style={styles.confirmRow}>
+                    <Text style={styles.confirmLabel}>From</Text>
+                    <Text style={styles.confirmValue} numberOfLines={2}>
+                      {waitlistConfirmRide.fromAddress}
+                    </Text>
+                  </View>
+
+                  <View style={styles.confirmRow}>
+                    <Text style={styles.confirmLabel}>To</Text>
+                    <Text style={styles.confirmValue} numberOfLines={2}>
+                      {waitlistConfirmRide.toAddress}
+                    </Text>
+                  </View>
+
+                  <View style={styles.confirmDivider} />
+
+                  <View style={styles.confirmRow}>
+                    <Text style={styles.confirmLabel}>Hold amount</Text>
+                    <Text style={styles.confirmValue}>
+                      ${toNumber(waitlistConfirmRide.price).toFixed(2)}
+                    </Text>
+                  </View>
+
+                  <Text style={styles.confirmTinyNote}>
+                    Your card will be authorized but not charged. The hold will be released if you leave the waitlist.
+                  </Text>
+                </>
+              )}
+
+              <View style={styles.confirmActions}>
+                <TouchableOpacity
+                  style={styles.cancelBtn}
+                  onPress={closeWaitlistConfirm}
+                  disabled={isJoiningWaitlist}
+                >
+                  <Text style={styles.cancelBtnText}>Cancel</Text>
+                </TouchableOpacity>
+
+                <TouchableOpacity
+                  style={[styles.payBtn, isJoiningWaitlist && { opacity: 0.7 }]}
+                  onPress={() => handleJoinWaitlist(waitlistConfirmRide)}
+                  disabled={isJoiningWaitlist}
+                >
+                  <Text style={styles.payBtnText}>
+                    {isJoiningWaitlist ? "Processing..." : "Hold & Join Waitlist"}
+                  </Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </Modal>
+
+        {/* Waitlist Position Modal */}
+        <Modal
+          animationType="fade"
+          transparent
+          visible={waitlistModalVisible}
+          onRequestClose={closeWaitlistModal}
+        >
+          <View style={styles.waitlistModalOverlay}>
+            <View style={styles.waitlistModalCard}>
+              <Text style={styles.waitlistModalTitle}>Waitlist Position</Text>
+              <Text style={styles.waitlistModalPosition}>
+                #{waitlistModalRide ? (waitlistPositions[waitlistModalRide.id] ?? "—") : ""}
+              </Text>
+              <Text style={styles.waitlistModalDesc}>
+                You are #{waitlistModalRide ? (waitlistPositions[waitlistModalRide.id] ?? "—") : ""} on the waitlist for this ride.
+              </Text>
+              <View style={styles.waitlistModalActions}>
+                <TouchableOpacity
+                  style={styles.waitlistModalCloseBtn}
+                  onPress={closeWaitlistModal}
+                >
+                  <Text style={styles.waitlistModalCloseBtnText}>Close</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  style={styles.waitlistModalLeaveBtn}
+                  onPress={() => {
+                    const ride = waitlistModalRide;
+                    closeWaitlistModal();
+                    handleLeaveWaitlist(ride);
+                  }}
+                >
+                  <Text style={styles.waitlistModalLeaveBtnText}>Leave Waitlist</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </View>
+        </Modal>
 
         {/* Filter Modal */}
         <Modal
@@ -1126,6 +1480,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
+    gap: 10,
   },
   viewDetailsButton: {
     backgroundColor: colors.background,
@@ -1462,6 +1817,131 @@ const styles = StyleSheet.create({
   },
   joinButtonTextDisabled: {
     color: "#111111",
+  },
+  waitlistButtonGroup: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  soldOutStack: {
+    flexDirection: "column",
+    alignItems: "stretch",
+    gap: 6,
+  },
+  waitlistedRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  waitlistedInner: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    position: "relative",
+    width: "100%",
+  },
+  waitlistInlineInfo: {
+    fontSize: 17,
+    position: "absolute",
+    right: 0,
+  },
+  waitlistButton: {
+    backgroundColor: "#f59e0b",
+  },
+  waitlistButtonText: {
+    color: colors.white,
+  },
+  waitlistActiveButton: {
+    backgroundColor: "#fbbf24",
+    borderWidth: 1,
+    borderColor: "#d97706",
+    paddingHorizontal: 10,
+    marginLeft: 50,
+  },
+  waitlistActiveButtonText: {
+    color: "#78350f",
+    fontSize: 14,
+    fontWeight: "bold",
+  },
+  waitlistModalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0, 0, 0, 0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  waitlistModalCard: {
+    backgroundColor: colors.white,
+    borderRadius: 16,
+    padding: 24,
+    width: "80%",
+    alignItems: "center",
+  },
+  waitlistModalTitle: {
+    fontSize: 20,
+    fontWeight: "bold",
+    color: colors.textPrimary,
+    marginBottom: 12,
+  },
+  waitlistModalPosition: {
+    fontSize: 48,
+    fontWeight: "bold",
+    color: "#d97706",
+    marginBottom: 8,
+  },
+  waitlistModalDesc: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    textAlign: "center",
+    marginBottom: 20,
+  },
+  waitlistModalActions: {
+    flexDirection: "row",
+    gap: 12,
+    width: "100%",
+  },
+  waitlistModalCloseBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    alignItems: "center",
+  },
+  waitlistModalCloseBtnText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: colors.textPrimary,
+  },
+  waitlistModalLeaveBtn: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: "#dc2626",
+    alignItems: "center",
+  },
+  waitlistModalLeaveBtnText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: colors.white,
+  },
+  waitlistInfoBtn: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#fef3c7",
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: "#f59e0b",
+  },
+  waitlistInfoIcon: {
+    fontSize: 14,
+    marginRight: 4,
+  },
+  waitlistPositionText: {
+    fontSize: 13,
+    fontWeight: "bold",
+    color: "#92400e",
   },
   
   // Filter Modal

--- a/rideshare-app/functions/.secret.local.example
+++ b/rideshare-app/functions/.secret.local.example
@@ -1,0 +1,1 @@
+STRIPE_SECRET_KEY=replace_with_your_stripe_secret_key

--- a/rideshare-app/functions/index.js
+++ b/rideshare-app/functions/index.js
@@ -1,6 +1,11 @@
 const { onCall, HttpsError } = require("firebase-functions/v2/https");
+const { initializeApp } = require("firebase-admin/app");
+const { getFirestore, FieldValue } = require("firebase-admin/firestore");
 
-exports.createPaymentIntent = onCall(async (request) => {
+initializeApp();
+const adminDb = getFirestore();
+
+exports.createPaymentIntent = onCall({ secrets: ["STRIPE_SECRET_KEY"] }, async (request) => {
   const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
 
   if (!request.auth) {
@@ -35,6 +40,356 @@ exports.createPaymentIntent = onCall(async (request) => {
     };
   } catch (error) {
     console.error("Stripe error:", error.message);
+    throw new HttpsError("internal", error.message);
+  }
+});
+
+exports.createWaitlistHold = onCall({ secrets: ["STRIPE_SECRET_KEY"] }, async (request) => {
+  const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+
+  if (!request.auth) {
+    throw new HttpsError("unauthenticated", "You must be signed in.");
+  }
+
+  const { amount, rideId } = request.data;
+
+  if (!amount || typeof amount !== "number" || amount <= 0) {
+    throw new HttpsError("invalid-argument", "A valid positive amount is required.");
+  }
+
+  if (!rideId || typeof rideId !== "string") {
+    throw new HttpsError("invalid-argument", "A valid rideId is required.");
+  }
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: Math.round(amount),
+      currency: "usd",
+      capture_method: "manual",
+      automatic_payment_methods: { enabled: true },
+      metadata: {
+        rideId: rideId,
+        userId: request.auth.uid,
+        userEmail: request.auth.token.email || "",
+        type: "waitlist_hold",
+      },
+    });
+
+    return {
+      clientSecret: paymentIntent.client_secret,
+      paymentIntentId: paymentIntent.id,
+    };
+  } catch (error) {
+    console.error("Stripe waitlist hold error:", error.message);
+    throw new HttpsError("internal", error.message);
+  }
+});
+
+exports.cancelWaitlistHold = onCall({ secrets: ["STRIPE_SECRET_KEY"] }, async (request) => {
+  const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+
+  if (!request.auth) {
+    throw new HttpsError("unauthenticated", "You must be signed in.");
+  }
+
+  const { paymentIntentId } = request.data;
+
+  if (!paymentIntentId || typeof paymentIntentId !== "string") {
+    throw new HttpsError("invalid-argument", "A valid paymentIntentId is required.");
+  }
+
+  try {
+    await stripe.paymentIntents.cancel(paymentIntentId);
+    return { success: true };
+  } catch (error) {
+    console.error("Stripe cancel hold error:", error.message);
+    throw new HttpsError("internal", error.message);
+  }
+});
+
+/**
+ * Promote the first person on the waitlist into the ride.
+ * Captures their payment hold, adds them to joins, decrements seats,
+ * removes them from waitlist, and creates a notification.
+ */
+exports.promoteFromWaitlist = onCall({ secrets: ["STRIPE_SECRET_KEY"] }, async (request) => {
+  const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+
+  if (!request.auth) {
+    throw new HttpsError("unauthenticated", "You must be signed in.");
+  }
+
+  const { rideId } = request.data;
+
+  if (!rideId || typeof rideId !== "string") {
+    throw new HttpsError("invalid-argument", "A valid rideId is required.");
+  }
+
+  try {
+    // Get the ride to check if there are seats available
+    const rideRef = adminDb.collection("rides").doc(rideId);
+    const rideSnap = await rideRef.get();
+
+    if (!rideSnap.exists) {
+      return { promoted: false, reason: "Ride not found." };
+    }
+
+    const rideData = rideSnap.data();
+    const seatsAvailable = Number(rideData.seats);
+
+    if (!Number.isFinite(seatsAvailable) || seatsAvailable <= 0) {
+      return { promoted: false, reason: "No seats available." };
+    }
+
+    // Get the first person on the waitlist (ordered by joinedAt)
+    const waitlistSnap = await rideRef
+      .collection("waitlist")
+      .orderBy("joinedAt", "asc")
+      .limit(1)
+      .get();
+
+    if (waitlistSnap.empty) {
+      return { promoted: false, reason: "Waitlist is empty." };
+    }
+
+    const waitlistDoc = waitlistSnap.docs[0];
+    const waitlistData = waitlistDoc.data();
+    const riderId = waitlistDoc.id;
+    const { paymentIntentId: holdId, riderEmail } = waitlistData;
+
+    // Try to capture the payment hold
+    let captureSuccess = false;
+    if (holdId) {
+      try {
+        const pi = await stripe.paymentIntents.retrieve(holdId);
+        if (pi.status === "requires_capture") {
+          await stripe.paymentIntents.capture(holdId);
+          captureSuccess = true;
+        } else {
+          // Hold expired or already canceled — still promote but note no charge
+          console.warn(`Hold ${holdId} status is ${pi.status}, cannot capture.`);
+        }
+      } catch (captureErr) {
+        console.error("Failed to capture hold:", captureErr.message);
+        // Still promote the rider even if capture fails
+      }
+    }
+
+    // Run a transaction to add rider to joins, decrement seats, remove from waitlist
+    await adminDb.runTransaction(async (tx) => {
+      const freshRideSnap = await tx.get(rideRef);
+      if (!freshRideSnap.exists) throw new Error("Ride no longer exists.");
+
+      const freshRideData = freshRideSnap.data();
+      const currentSeats = Number(freshRideData.seats);
+
+      if (!Number.isFinite(currentSeats) || currentSeats <= 0) {
+        throw new Error("No seats available.");
+      }
+
+      const joinRef = rideRef.collection("joins").doc(riderId);
+      const joinSnap = await tx.get(joinRef);
+
+      if (joinSnap.exists) {
+        // Already joined somehow — just remove from waitlist
+        tx.delete(rideRef.collection("waitlist").doc(riderId));
+        return;
+      }
+
+      // Add to joins
+      tx.set(joinRef, {
+        riderId: riderId,
+        riderEmail: riderEmail || "",
+        joinedAt: FieldValue.serverTimestamp(),
+        pricePaid: Number(freshRideData.price) || 0,
+        paymentIntentId: holdId || "",
+        promotedFromWaitlist: true,
+      });
+
+      // Decrement seats
+      tx.update(rideRef, {
+        seats: currentSeats - 1,
+        total_seats: freshRideData.total_seats ?? currentSeats,
+      });
+
+      // Remove from waitlist
+      tx.delete(rideRef.collection("waitlist").doc(riderId));
+    });
+
+    // Create a notification for the promoted rider
+    await adminDb.collection("notifications").add({
+      userId: riderId,
+      type: "waitlist_promoted",
+      title: "You Got a Seat!",
+      body: "A spot opened up and you've been added to the ride. Your payment hold has been captured.",
+      rideId: rideId,
+      driverId: rideData.ownerId || "",
+      fromAddress: rideData.fromAddress || "",
+      toAddress: rideData.toAddress || "",
+      createdAt: FieldValue.serverTimestamp(),
+      readAt: null,
+    });
+
+    return {
+      promoted: true,
+      riderId: riderId,
+      captureSuccess: captureSuccess,
+    };
+  } catch (error) {
+    console.error("Promote from waitlist error:", error.message);
+    throw new HttpsError("internal", error.message);
+  }
+});
+
+/**
+ * Leave a ride and immediately promote the first waitlisted user in one
+ * server-side call so there is no client round-trip delay between the two.
+ */
+exports.leaveRideAndPromote = onCall({ secrets: ["STRIPE_SECRET_KEY"] }, async (request) => {
+  const stripe = require("stripe")(process.env.STRIPE_SECRET_KEY);
+
+  if (!request.auth) {
+    throw new HttpsError("unauthenticated", "You must be signed in.");
+  }
+
+  const { rideId } = request.data;
+  if (!rideId || typeof rideId !== "string") {
+    throw new HttpsError("invalid-argument", "A valid rideId is required.");
+  }
+
+  const leavingUid = request.auth.uid;
+  const rideRef = adminDb.collection("rides").doc(rideId);
+
+  try {
+    // ── Step 1: Leave the ride ──────────────────────────────────────────
+    let rideData;
+    await adminDb.runTransaction(async (tx) => {
+      const rideSnap = await tx.get(rideRef);
+      const joinRef = rideRef.collection("joins").doc(leavingUid);
+      const joinSnap = await tx.get(joinRef);
+
+      if (!rideSnap.exists) throw new Error("Ride no longer exists.");
+      if (!joinSnap.exists) throw new Error("You have not joined this ride.");
+
+      rideData = rideSnap.data();
+      const seatsNum = Number(rideData.seats) || 0;
+      const totalSeatsRaw = Number(rideData.total_seats ?? seatsNum);
+      const totalSeats = Number.isFinite(totalSeatsRaw) ? totalSeatsRaw : null;
+      const nextSeats = totalSeats !== null
+        ? Math.min(seatsNum + 1, totalSeats)
+        : seatsNum + 1;
+
+      tx.update(rideRef, {
+        seats: nextSeats,
+        total_seats: rideData.total_seats ?? seatsNum,
+      });
+      tx.delete(joinRef);
+    });
+
+    // ── Step 2: Promote the first waitlisted rider (if any) ─────────────
+    const waitlistSnap = await rideRef
+      .collection("waitlist")
+      .orderBy("joinedAt", "asc")
+      .limit(1)
+      .get();
+
+    let promoted = false;
+    let promotedRiderId = null;
+
+    if (!waitlistSnap.empty) {
+      const waitlistDoc = waitlistSnap.docs[0];
+      const waitlistData = waitlistDoc.data();
+      promotedRiderId = waitlistDoc.id;
+      const holdId = waitlistData.paymentIntentId;
+      const riderEmail = waitlistData.riderEmail || "";
+
+      // Capture the Stripe hold before committing the promotion
+      if (holdId) {
+        try {
+          const pi = await stripe.paymentIntents.retrieve(holdId);
+          if (pi.status === "requires_capture") {
+            await stripe.paymentIntents.capture(holdId);
+          }
+        } catch (captureErr) {
+          console.error("Failed to capture hold:", captureErr.message);
+        }
+      }
+
+      await adminDb.runTransaction(async (tx) => {
+        const freshRideSnap = await tx.get(rideRef);
+        if (!freshRideSnap.exists) throw new Error("Ride no longer exists.");
+
+        const freshRideData = freshRideSnap.data();
+        const currentSeats = Number(freshRideData.seats);
+        if (!Number.isFinite(currentSeats) || currentSeats <= 0) {
+          throw new Error("No seats available for promotion.");
+        }
+
+        const promoteJoinRef = rideRef.collection("joins").doc(promotedRiderId);
+        const existingJoin = await tx.get(promoteJoinRef);
+        if (existingJoin.exists) {
+          tx.delete(rideRef.collection("waitlist").doc(promotedRiderId));
+          return;
+        }
+
+        tx.set(promoteJoinRef, {
+          riderId: promotedRiderId,
+          riderEmail: riderEmail,
+          joinedAt: FieldValue.serverTimestamp(),
+          pricePaid: Number(freshRideData.price) || 0,
+          paymentIntentId: holdId || "",
+          promotedFromWaitlist: true,
+        });
+        tx.update(rideRef, {
+          seats: currentSeats - 1,
+          total_seats: freshRideData.total_seats ?? currentSeats,
+        });
+        tx.delete(rideRef.collection("waitlist").doc(promotedRiderId));
+        promoted = true;
+      });
+
+      if (promoted) {
+        // Add promoted rider to the ride conversation
+        const convoRef = adminDb.collection("conversations").doc(rideId);
+        try {
+          let promotedName = riderEmail;
+          const promotedUserDoc = await adminDb.collection("users").doc(promotedRiderId).get();
+          if (promotedUserDoc.exists) {
+            promotedName = promotedUserDoc.data().name || promotedName;
+          }
+          await convoRef.update({
+            participants: FieldValue.arrayUnion(promotedRiderId),
+            [`participantNames.${promotedRiderId}`]: promotedName,
+            [`lastReadAt.${promotedRiderId}`]: FieldValue.serverTimestamp(),
+          });
+        } catch (convoErr) {
+          console.warn("Could not add promoted rider to conversation:", convoErr.message);
+        }
+
+        // Notification
+        await adminDb.collection("notifications").add({
+          userId: promotedRiderId,
+          type: "waitlist_promoted",
+          title: "You Got a Seat!",
+          body: "A spot opened up and you've been added to the ride. Your payment hold has been captured.",
+          rideId: rideId,
+          driverId: rideData.ownerId || "",
+          fromAddress: rideData.fromAddress || "",
+          toAddress: rideData.toAddress || "",
+          createdAt: FieldValue.serverTimestamp(),
+          readAt: null,
+        });
+      }
+    }
+
+    return {
+      success: true,
+      promoted: promoted,
+      promotedRiderId: promotedRiderId,
+      ownerId: rideData.ownerId || "",
+    };
+  } catch (error) {
+    console.error("leaveRideAndPromote error:", error.message);
     throw new HttpsError("internal", error.message);
   }
 });

--- a/rideshare-app/functions/package-lock.json
+++ b/rideshare-app/functions/package-lock.json
@@ -14,7 +14,7 @@
         "firebase-functions-test": "^3.4.1"
       },
       "engines": {
-        "node": "24"
+        "node": "20"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/rideshare-app/functions/package.json
+++ b/rideshare-app/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "24"
+    "node": "20"
   },
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Closes #181 
Closes #182
Closes #184

-  When a rider leaves a ride, the first person on the waitlist is now promoted with minimal delay. 
- Promoted riders are automatically added to the ride conversation. 
- Waitlisted users who get promoted into a ride will now see the ride chat in their Messages tab right away, just like any other rider who joined normally.
- Created a new leaveRideAndPromote Cloud Function that combines leaving a ride and promoting the first waitlisted user into a single server-side operation, eliminating the extra client-server round trip that previously caused a delay between the two steps
- Downgraded from Node.js 24 to Node.js 20 to resolve compatibility issues with Firebase Cloud Functions deployment, which targets the Node 20 runtime.
- You can no longer join the waitlist for a ride that departs within the next 24 hours, preventing last-minute holds that are unlikely to result in a seat.
-  Rides that have already passed their departure time no longer appear in the list of available rides.

<img width="603" height="1311" alt="IMG_6702" src="https://github.com/user-attachments/assets/73eee3ac-efe9-4544-88b5-625ce79df88e" />

<img width="603" height="1311" alt="IMG_6700" src="https://github.com/user-attachments/assets/bcd600ff-f7cd-4997-96e4-bf3d05f72c40" />

<img width="603" height="1311" alt="IMG_6701" src="https://github.com/user-attachments/assets/f75e87ed-6c3d-4786-a80d-ec1a72edc202" />

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/d32d139c-1ac0-415d-ac03-eafb7d34fa8d" />

